### PR TITLE
Make reveal work with new notebook layout

### DIFF
--- a/livereveal/main.css
+++ b/livereveal/main.css
@@ -68,6 +68,9 @@
 div#notebook {
   overflow-x: hidden;
 }
+div#notebook.reveal {
+  padding-top: 0px;
+}
 div#notebook-container {
   background-color: transparent;
   -webkit-box-shadow: none;
@@ -99,4 +102,3 @@ div.output_subarea {
 html {
   overflow-y: auto;
 }
-

--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -125,14 +125,14 @@ function labelIntraSlides(){
 
 function Slider(begin, end, container) {
   // Hiding header and the toolbar
-  $('div#header-container').toggle();
+  $('div#header').toggle();
   $('div#maintoolbar').toggle();
   IPython.menubar._size_header();
   //if(event)event.preventDefault();
 
   // switch the panel back color to white (it does not work in css,
   // I do not why, so switching by js)
-  $('div#notebook_panel').css('background-color','#ffffff');
+  $('div#site').css('background-color','#ffffff');
 
   /*
    * The crazy rearrangement, I read the following some months ago,
@@ -191,6 +191,8 @@ function Slider(begin, end, container) {
 
 function Revealer(ttheme, ttransition){
   // Bodier
+  $('div#site').css("height", "100%");  
+  $('div#ipython-main-app').css("position", "static");
   $('div#notebook').addClass("reveal");
   $('div#notebook-container').addClass("slides");
 
@@ -249,6 +251,7 @@ function Revealer(ttheme, ttransition){
     Reveal.addEventListener( 'ready', function( event ) {
       Unselecter();
       IPython.notebook.scroll_to_top();
+      Reveal.layout();
     });
 
     Reveal.addEventListener( 'slidechanged', function( event ) {
@@ -336,7 +339,7 @@ function buttonExit() {
         .addClass(exit_icon)
         .addClass('my-main-tool-bar')
         .css('position','fixed')
-        .css('top','1.0em')
+        .css('top','0.5em')
         .css('left','0.48em')
         .css('opacity', '0.6')
         .click(
@@ -348,15 +351,18 @@ function buttonExit() {
 }
 
 function Remover() {
-  $('div#notebook_panel').css('background-color','#ffffff');
-  $('div#header-container').toggle();
+  $('div#site').css("height", "");  
+  $('div#site').css('background-color','');
+  $("div#ipython-main-app").css("position", "");
+  $('div#header').toggle();
   $('div#maintoolbar').toggle();
   IPython.menubar._size_header();
 
   $('div#notebook').removeClass("reveal");
   $('div#notebook-container').removeClass("slides");
-  $('div#notebook-container').css('width','1140px');
-  $('div#notebook-container').css('height','inherit');
+  $('div#notebook-container').css('width','');
+  $('div#notebook-container').css('height','');
+  $('div#notebook-container').css('zoom','');
 
   $('#maincss').remove();
   $('#theme').remove();

--- a/livereveal/reset_reveal.css
+++ b/livereveal/reset_reveal.css
@@ -79,6 +79,7 @@ body {
 
 	word-wrap: break-word;
 	line-height: 1;
+	margin-top: 0px !important;
 }
 
 .reveal h1 { font-size: 3.77em; }


### PR DESCRIPTION
This makes changes so that the following notebook:

![image](https://cloud.githubusercontent.com/assets/83444/5907038/d50b6150-a550-11e4-9f9c-07b72fc7ee35.png)

now looks like this when using the live reveal plugin on IPython master:

![image](https://cloud.githubusercontent.com/assets/83444/5907059/ff3999c4-a550-11e4-8a35-7c3998b37416.png)
