### PR TITLE
Ubuntu 14.04 IPython notebook does not have IPython.menu._size_header

### DIFF
--- a/livereveal/main.js
+++ b/livereveal/main.js
@@ -127,7 +127,9 @@ function Slider(begin, end, container) {
   // Hiding header and the toolbar
   $('div#header').toggle();
   $('div#maintoolbar').toggle();
-  IPython.menubar._size_header();
+  if(IPython.menubar._size_header) {
+		IPython.menubar._size_header();
+  }
   //if(event)event.preventDefault();
 
   // switch the panel back color to white (it does not work in css,
@@ -367,8 +369,9 @@ function Remover() {
   $("div#ipython-main-app").css("position", "");
   $('div#header').toggle();
   $('div#maintoolbar').toggle();
-  IPython.menubar._size_header();
-
+  if(IPython.menubar._size_header) {
+		IPython.menubar._size_header();
+  }
   $('div#notebook').removeClass("reveal");
   $('div#notebook-container').removeClass("slides");
   $('div#notebook-container').css('width','');


### PR DESCRIPTION
live_real did not work for me. My IPython notebook is ver 2.31 bundled in Ubuntu 14.04 (apt-get version).
I check the javascript console and find out an error caused by `IPython.menu._size_header` not defined. After I commented out these line, live_real seems to work fine. 
So I add a check to see whether `IPython.menu._size_header` is defined before calling it.

